### PR TITLE
fix: prevent 'admin with no permissions' on fresh install

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -101,8 +101,15 @@ func runInit(cmd *cobra.Command, args []string) {
 	// Create default policy file with RBAC roles (only if not exists or --force)
 	policyCreated, err := createDefaultPolicy()
 	if err != nil {
-		printWarn(fmt.Sprintf("Failed to create policy file: %v", err))
-		fmt.Println(indent("You can manually create it later using the dashboard"))
+		printError(fmt.Sprintf("Failed to create policy file: %v", err))
+		fmt.Println()
+		printError("This is a critical error. Initialization cannot continue.")
+		fmt.Println(indent("Possible causes:"))
+		fmt.Println(indent("  - Disk write permissions (try running as administrator on Windows)"))
+		fmt.Println(indent("  - Antivirus blocking file creation (add sym to exclusions)"))
+		fmt.Println(indent("  - OneDrive/Dropbox sync conflict (pause sync temporarily)"))
+		fmt.Println(indent("  - Disk full or read-only filesystem"))
+		os.Exit(1)
 	} else if policyCreated {
 		printOK("user-policy.json created with default RBAC roles")
 	} else {


### PR DESCRIPTION
Fixes permission issues when user-policy.json creation fails or is missing.

Changes:
1. init.go: Make createDefaultPolicy() failure fatal
   - Previously: warning only, continued execution
   - Now: exits with detailed error message
   - Provides actionable guidance (antivirus, permissions, disk space)

2. manager.go: Add safe RBAC fallback in LoadPolicy()
   - Previously: returned RBAC=nil when file missing
   - Now: returns minimal admin role with full permissions
   - Prevents "admin with no permissions" scenario in dashboard

3. manager.go: Enhanced error messages for SavePolicy()
   - Added specific causes for write failures
   - Windows-specific guidance (antivirus, OneDrive, UAC)

Root Cause:
- On Windows, file write can fail due to:
  * Antivirus real-time protection scanning binary
  * OneDrive/Dropbox sync conflicts
  * Controlled Folder Access (ransomware protection)
  * Transient I/O errors
- Silent failure left .env with CURRENT_ROLE=admin but no policy file
- Dashboard loaded RBAC=nil → permission check failed

Impact:
- Prevents confusing UX where admin role has no edit buttons
- Provides clear error messages to help users resolve issues
- Fails fast instead of creating inconsistent state